### PR TITLE
Remove false limitations in cassandra docs

### DIFF
--- a/presto-docs/src/main/sphinx/connector/cassandra.rst
+++ b/presto-docs/src/main/sphinx/connector/cassandra.rst
@@ -228,5 +228,3 @@ Limitations
 * Queries without filters containing the partition key result in fetching all partitions.
   This causes a full scan of the entire data set, therefore it's much slower compared to a similar
   query with a partition key as a filter.
-* ``IN`` list filters are only allowed on index (that is, partition key or clustering key) columns.
-* Range (``<`` or ``>`` and ``BETWEEN``) filters can be applied only to the partition keys.


### PR DESCRIPTION
I did found these limitations to be false, at least as written.

For example, on a cassandra table partitioned on column id. 

presto:feeds> select member_id, count(*) as c from following_set_by_id where timestamp_created > now() - interval '9' day and member_id in('SJPm15sSQwqjhM9idj_LcQ') ;

Works fine.